### PR TITLE
修复转发开始后连接弹幕服务器的-352错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ B站直播歌词/同传弹幕发送工具
 │  │  live_chaser.py            B站直播追帧工具
 │  │  live_websocket.py         B站直播websocket工具
 │  │  util.py                   自定义工具类
+│  │  w_rid.py                  B站校验字段的生成算法
 ```
 
 引用项目：

--- a/utils/w_rid.py
+++ b/utils/w_rid.py
@@ -1,0 +1,84 @@
+import abc
+import hashlib
+import json
+import threading
+import time
+
+import requests
+
+
+def get_UA():
+    return {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+                     "Chrome/118.0.0.0 Safari/537.36 Edg/118.0.2088.61"
+    }
+
+
+class AutoExpireInterface(abc.ABC):
+    __refresh_time: int
+    __data = {}
+    __next_refresh_time: int
+    __refresh_lock = threading.Lock()
+
+    def __init__(self, refresh_time: int):
+        self.__refresh_time = refresh_time
+        self.__next_refresh_time = 0
+
+    async def refresh(self, **kwargs):
+        pass
+
+    async def get(self, **kwargs):
+        with self.__refresh_lock:
+            cur_time = int(time.time())
+            if cur_time > self.__next_refresh_time:
+                try:
+                    self.__data = await self.refresh(**kwargs)
+                except... as e:
+                    print(f"refresh fail !error {e}")
+                self.__next_refresh_time = cur_time + self.__refresh_time
+        return self.__data
+
+
+def get_mixin_key(img_key, sub_key):
+    key = img_key + sub_key
+    mixin_key = ''.join([key[i] for i in
+                         [46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35,
+                          27, 43, 5, 49, 33, 9, 42, 19, 29, 28, 14, 39, 12, 38, 41, 13,
+                          37, 48, 7, 16, 24, 55, 40, 61, 26, 17, 0, 1, 60, 51, 30, 4, 22,
+                          25, 54, 21, 56, 59, 6, 63, 57, 62, 11, 36, 20, 34, 44, 52]][:32])
+    return mixin_key
+
+
+class WbiKey(AutoExpireInterface):
+    async def refresh(self, **kwargs):
+        # 这里未登录（不提供session）也可以
+        wbi_res = requests.get("https://api.bilibili.com/x/web-interface/nav", **{
+                        "headers": get_UA()})
+        if wbi_res.status_code != 200:
+            print(f"WbiKey refresh fail. status_code = {wbi_res.status_code}")
+        wei_data = json.loads(wbi_res.text)["data"]
+        data = {
+            "img_url": wei_data["wbi_img"]["img_url"].rsplit("/", 1)[1].split(".")[0],
+            "sub_url": wei_data["wbi_img"]["sub_url"].rsplit("/", 1)[1].split(".")[0]
+        }
+        print(f"refresh wbi key success. wbi_key = {data}")
+        return data
+
+
+wbi_key = WbiKey(86400)
+
+
+async def fill_wrid_wts(params):
+    wbi_key_data = await wbi_key.get()
+    img_key, sub_key = wbi_key_data["img_url"], wbi_key_data["sub_url"]
+    mixin_key = get_mixin_key(img_key, sub_key)
+    wts = int(time.time())
+    data = {
+        "wts": wts
+    }
+    data.update(params)
+    dst_key = '&'.join(f'{k}={v}' for k, v in sorted(data.items())) + mixin_key
+
+    w_rid = hashlib.md5(dst_key.encode(encoding="utf-8")).hexdigest()
+    params["w_rid"] = w_rid
+    params["wts"] = wts


### PR DESCRIPTION
阿B弹幕服的验证现在和拉取个人信息，拉取动态时保持一致，均需要填充w_rid和wts字段才可以过验证，不然会返回-352。

wts：当前时间戳，与当前时间有一段时间不一致也没关系，主要为了过验证用。
w_rid：所有请求字段按字母顺序排列并组成x1=y1&x2=y2...的形式后拼接上mixin_key后生成的md5字符串。

mixin_key生成：
①请求https://api.bilibili.com/x/web-interface/nav   拿img_url和sub_url（两个url看上去是png图片实际上就是俩验证字符串，取中间实际内容部分即可）。理论上1天要刷新一次，但实际也没人会挂1整天的同传工具吧（
②img_url+sub_url后按照索引置换表取32个字符形成最终的mixin_key字符串（顺序是抄的B站前端js代码）。