### PR TITLE
修复连接直播间时只能收到部分消息问题

### DIFF
--- a/frame/bili_qrcode.py
+++ b/frame/bili_qrcode.py
@@ -56,7 +56,7 @@ class BiliQrCodeFrame(wx.Frame):
                         session=requests.Session()
                         session.get(url=data["data"]["url"],headers=self.blApi.headers)
                         _dict=session.cookies.get_dict()
-                        cookie=f"buvid3={_dict['buvid3']};SESSDATA={_dict['SESSDATA']};bili_jct={_dict['bili_jct']}"
+                        cookie=f"buvid3={_dict['buvid3']};SESSDATA={_dict['SESSDATA']};bili_jct={_dict['bili_jct']};DedeUserId={_dict['DedeUserID']}"
                         self.Parent.SetLoginInfo(cookie,self.acc_no)
                         showInfoDialog("登录成功","提示")
                     except Exception as e:

--- a/frame/danmu_spread.py
+++ b/frame/danmu_spread.py
@@ -171,7 +171,7 @@ class DanmuSpreadFrame(wx.Frame):
             self.configs[slot][4].append(False)
         if index>0 and self.configs[slot][1]:
             if roomid not in self.websockets.keys():
-                self.websockets[roomid]=BiliLiveWebSocket(roomid)
+                self.websockets[roomid]=BiliLiveWebSocket(roomid, self.GetCookies())
             self.websockets[roomid].ChangeRefCount(+1)
             if old_rid is not None:
                 self.websockets[old_rid].ChangeRefCount(-1)
@@ -185,7 +185,7 @@ class DanmuSpreadFrame(wx.Frame):
                 cfg[0][index]=new
                 if index>0 and cfg[1]: count+=1
         if new not in self.websockets.keys():
-            self.websockets[new]=BiliLiveWebSocket(new)
+            self.websockets[new]=BiliLiveWebSocket(new, self.GetCookies())
         self.websockets[new].ChangeRefCount(+count)
         if old in self.websockets.keys():
             self.websockets[old].ChangeRefCount(-count)
@@ -242,10 +242,7 @@ class DanmuSpreadFrame(wx.Frame):
         })
         for roomid in self.configs[slot][0][1:]:
             if roomid not in self.websockets.keys():
-                # 需要传入一个"已经激活的buvid3"才能正常获取直播间的地址
-                match = re.search(r'buvid3=([^;]+)', self.Parent.cookies[0])
-                buvid3_value = match.group(1)
-                self.websockets[roomid]=BiliLiveWebSocket(roomid, buvid3_value)
+                self.websockets[roomid]=BiliLiveWebSocket(roomid, self.GetCookies())
             self.websockets[roomid].ChangeRefCount(+1 if spreading else -1)
         self.RefreshUI()
     
@@ -399,6 +396,17 @@ class DanmuSpreadFrame(wx.Frame):
     def RecordFail(self):
         self.fail_count+=1
         UIChange(self.lblFail,label=f"失败:{self.fail_count}")
+
+    def GetCookies(self):
+        # 现在必须传入完整session才能拿到全部的弹幕信息
+        # 写死拿账号1的
+        match = re.search(r'buvid3=([^;]*);SESSDATA=([^;]*);bili_jct=([^;]*);DedeUserId=([^;]*)', self.Parent.cookies[0])
+        return {
+            "buvid3": match and match.group(1),
+            "SESSDATA": match and match.group(2),
+            "bili_jct": match and match.group(3),
+            "DedeUserId": match and match.group(4),
+        }
 
 class SpreadFilterFrame(wx.Frame):
     def __init__(self, parent, slot, index):

--- a/utils/api.py
+++ b/utils/api.py
@@ -210,8 +210,9 @@ class BiliLiveAPI(BaseAPI):
         mo1 = re.search(r"buvid3=([^;]+)", cookie)
         mo2 = re.search(r"SESSDATA=([^;]+)", cookie)
         mo3 = re.search(r"bili_jct=([^;]+)", cookie)
-        buvid3,sessdata,bili_jct=mo1.group(1) if mo1 else "",mo2.group(1) if mo2 else "",mo3.group(1) if mo3 else ""
-        cookie="buvid3=%s;SESSDATA=%s;bili_jct=%s"%(buvid3,sessdata,bili_jct)
+        mo4 = re.search(r"DedeUserId=([^;]+)", cookie)
+        buvid3,sessdata,bili_jct,deceuserid=mo1.group(1) if mo1 else "",mo2.group(1) if mo2 else "",mo3.group(1) if mo3 else "",mo4.group(1) if mo4 else ""
+        cookie="buvid3=%s;SESSDATA=%s;bili_jct=%s;DedeUserId=%s"%(buvid3,sessdata,bili_jct,deceuserid)
         requests.utils.add_dict_to_cookiejar(self.sessions[number].cookies,{"Cookie": cookie})
         self.csrfs[number]=bili_jct
         return cookie

--- a/utils/live_websocket.py
+++ b/utils/live_websocket.py
@@ -12,10 +12,10 @@ from utils.util import getTime, logDebug
 from utils.w_rid import get_UA, fill_wrid_wts
 
 
-class BiliLiveWebSocket():
+class BiliLiveWebSocket:
     __TL_PATTERN1=r"^【(?P<speaker>[^:：]{1,5})[:：](?P<content>[^】]+)"
     __TL_PATTERN2=r"^(?P<speaker>[^\u0592✉【][^【]{0,4})?【(?P<content>[^】]+)"
-    __URI="wss://{host}:{wss_port}/sub"
+    __URI="wss://{host}/sub"
     __HEARTBEAT_PKG="00000010001000010000000200000001"
     __ENTERROOM_HEADER="{:0>8x}001000010000000700000001"
     __URL_GETDANMUINFO="https://api.live.bilibili.com/xlive/web-room/v1/index/getDanmuInfo"
@@ -30,7 +30,7 @@ class BiliLiveWebSocket():
     :后续接数据包内容
     '''
 
-    def __init__(self,roomid, buvid3):
+    def __init__(self,roomid, session):
         self.__roomid=str(roomid)
         self.__ref_count=0
         self.__loop=asyncio.new_event_loop()
@@ -38,7 +38,7 @@ class BiliLiveWebSocket():
         self.__closing=False
         self.__error=False
         self.__hb_task=None
-        self.__buvid3=buvid3
+        self.__session=session
 
     async def __connect_to_room(self):
         self.__error=False
@@ -56,7 +56,9 @@ class BiliLiveWebSocket():
                     async with session.get(self.__URL_GETDANMUINFO, params=params, **{
                         "headers": get_UA(),
                         "cookies": {
-                            "buvid3": self.__buvid3
+                            "buvid3": self.__session["buvid3"],
+                            "SESSDATA": self.__session["SESSDATA"],
+                            "bili_jct": self.__session["bili_jct"],
                         }}) as res:
                         data = await res.json()
                         if data["code"]==0:
@@ -66,10 +68,11 @@ class BiliLiveWebSocket():
                         else:
                             print("获取弹幕服务器地址失败")
                 param={ # 建立连接时附带的数据包
-                    "uid": 0,
+                    "uid": int(self.__session["DedeUserId"]),
                     "roomid": int(self.__roomid),
                     "protover": 3,
                     "platform": "web",
+                    "buvid": self.__session["buvid3"],
                     "type": 2,
                     "key": token
                 }


### PR DESCRIPTION
问题原因：现在不把登录了的session带上来，就只能拿到一小部分弹幕信息；补全信息即可。

但是因为之前没存uid，而完整的弹幕协议校验需要uid值，所以现在需要重新扫码登录一遍QAQ

PS：我写的是直接取账号1（即cookies[0])的数据），所以账号1是必须要保证重新扫码过才能正常收发完整弹幕消息的。